### PR TITLE
Fix: Handle list or dict in ADK event content in app.py

### DIFF
--- a/app.py
+++ b/app.py
@@ -48,15 +48,28 @@ def call_agent_api(message_text):
         api_response_list = response.json()
         assistant_response_text = None
         
-        for event in api_response_list:
-            if "content" in event and event["content"].get("role") == "model":
-                for part in event["content"].get("parts", []):
-                    if "text" in part:
-                        assistant_response_text = part["text"]
-                        break
-                if assistant_response_text:
-                    break
-        
+        for event in api_response_list: 
+            if "content" in event:
+                actual_content_data = event["content"]
+                
+                content_list_to_process = []
+                if isinstance(actual_content_data, list):
+                    content_list_to_process.extend(actual_content_data)
+                elif isinstance(actual_content_data, dict):
+                    content_list_to_process.append(actual_content_data)
+
+                for content_item in content_list_to_process:
+                    if isinstance(content_item, dict) and content_item.get("role") == "model":
+                        for part in content_item.get("parts", []):
+                            if "text" in part:
+                                assistant_response_text = part["text"]
+                                break  # Found text in parts, break from parts loop
+                        if assistant_response_text:
+                            break  # Found text, break from content_item loop
+            
+            if assistant_response_text:
+                break # Found text, break from event loop
+                
         return assistant_response_text
 
     except requests.exceptions.RequestException as e:


### PR DESCRIPTION
Updated the `call_agent_api` function in `app.py` to correctly parse the ADK response. The previous logic assumed `event['content']` would always be a dictionary. This change allows `event['content']` to also be a list of content dictionaries, making the parsing more robust and preventing an `AttributeError: 'list' object has no attribute 'get'` when the ADK returns content in this list format.

The function now iterates through the potential list in `event['content']` or processes it as a single dictionary, searching for the model's text response in either case.