### PR TITLE
Add pandas to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 streamlit
 requests
+pandas


### PR DESCRIPTION
#The pandas library is a dependency for tools.py but was missing from requirements.txt. This change adds it to ensure it's installed when setting up the environment using pip install -r requirements.txt.